### PR TITLE
Fix Echo example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ implementation:
 ```rust
 use async_trait::async_trait;
 use maelstrom::protocol::Message;
-use maelstrom::{Node, Result, Runtime};
+use maelstrom::{done, Node, Result, Runtime};
 use std::sync::Arc;
 
 pub(crate) fn main() -> Result<()> {
@@ -57,7 +57,7 @@ impl Node for Handler {
             return runtime.reply(req, echo).await;
         }
 
-        done(runtime, message)
+        done(runtime, req)
     }
 }
 ```


### PR DESCRIPTION
I've taken the liberty to add a missing import and rename a variable in the echo example shown in the README.md and have checked that it passes the maelstrom test after the changes.